### PR TITLE
Add unique id to sensors

### DIFF
--- a/custom_components/renson/binary_sensor.py
+++ b/custom_components/renson/binary_sensor.py
@@ -106,6 +106,8 @@ class RensonBinarySensor(CoordinatorEntity, BinarySensorEntity):
         self.field = description.field
         self.entity_description = description
 
+        self._attr_unique_id = f"renson-{description.key}"
+
     @callback
     def _handle_coordinator_update(self) -> None:
         """Handle updated data from the coordinator."""

--- a/custom_components/renson/sensor.py
+++ b/custom_components/renson/sensor.py
@@ -310,6 +310,8 @@ class RensonSensor(CoordinatorEntity, SensorEntity):
         self.renson_api = renson_api
         self.raw_format = description.raw_format
 
+        self._attr_unique_id = f"renson-{description.key}"
+
     @property
     def native_value(self):
         """Return the value reported by the sensor."""


### PR DESCRIPTION
Adding a unique id to the sensors.

With this you can easily filter all entities from this integration in the Setting - Entities page